### PR TITLE
Fix yaml URL in installation documents

### DIFF
--- a/content/en/docs/installation/_index.md
+++ b/content/en/docs/installation/_index.md
@@ -13,7 +13,7 @@ The components of OCGI mainly include `Carrier` controller, `GPA` controller, an
   * Install CRD
 
 ```shell script
-# kubectl apply -f https://github.com/ocgi/carrier/blob/master/config/crd.yaml 
+# kubectl apply -f https://github.com/ocgi/carrier/blob/master/manifeasts/crd.yaml
 customresourcedefinition.apiextensions.k8s.io/gameservers.carrier.ocgi.dev created
 customresourcedefinition.apiextensions.k8s.io/gameserversets.carrier.ocgi.dev created
 customresourcedefinition.apiextensions.k8s.io/squads.carrier.ocgi.dev created
@@ -29,7 +29,7 @@ squads.carrier.ocgi.dev                 2020-11-23T06:48:59Z
   * Install Carrier
 
 ```shell script
-# kubectl apply -f https://github.com/ocgi/carrier/blob/master/deployment/deploy.yaml 
+# kubectl apply -f https://github.com/ocgi/carrier/blob/master/manifeasts/deploy.yaml
 serviceaccount/carrier created
 clusterrolebinding.rbac.authorization.k8s.io/carrier created
 deployment.apps/carrier created
@@ -40,7 +40,7 @@ deployment.apps/carrier created
   The service account is uesed by SDK-Sever, which is automatically injected into the application Pod as a Sidecar and accesses kube-apiserver.
 
 ```shell script
-# kubectl apply -f https://github.com/ocgi/carrier-sdk/blob/master/deployment/serviceaccount.yaml
+# kubectl apply -f https://github.com/ocgi/carrier-sdk/blob/master/manifeasts/serviceaccount.yaml
 clusterrole.rbac.authorization.k8s.io/carrier-sdk created
 serviceaccount/carrier-sdk created
 rolebinding.rbac.authorization.k8s.io/carrier-sdk-access created

--- a/content/zh/docs/installation/_index.md
+++ b/content/zh/docs/installation/_index.md
@@ -13,7 +13,7 @@ OCGI的组件，主要包括`Carrier` controller，`GPA` controller，`cost-serv
   * 创建CRD
 
 ```shell script
-# kubectl apply -f https://github.com/ocgi/carrier/blob/master/config/crd.yaml 
+# kubectl apply -f https://github.com/ocgi/carrier/blob/master/manifeasts/crd.yaml
 customresourcedefinition.apiextensions.k8s.io/gameservers.carrier.ocgi.dev created
 customresourcedefinition.apiextensions.k8s.io/gameserversets.carrier.ocgi.dev created
 customresourcedefinition.apiextensions.k8s.io/squads.carrier.ocgi.dev created
@@ -29,7 +29,7 @@ squads.carrier.ocgi.dev                 2020-11-23T06:48:59Z
   * 部署Carrier
 
 ```shell script
-# kubectl apply -f https://github.com/ocgi/carrier/blob/master/deployment/deploy.yaml 
+# kubectl apply -f https://github.com/ocgi/carrier/blob/master/manifeasts/deploy.yaml
 serviceaccount/carrier created
 clusterrolebinding.rbac.authorization.k8s.io/carrier created
 deployment.apps/carrier created


### PR DESCRIPTION
CRD, carrier and sdk's YAML URLs are changed to under the "manifests" directory. But docs are outdated. This patch fixes this.

## additional concern
The install step of the General Pod Autoscaler is also outdated. But it require execute bash scritpt, not "kubectl apply -f". I have no idea of how to update this documents.